### PR TITLE
Bugfix: Remove from Cart

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -414,6 +414,7 @@ def remove_from_cart(request, slug):
                 ordered=False
             )[0]
             order.items.remove(order_item)
+            order_item.delete()
             messages.info(request, "This item was removed from your cart.")
             return redirect("core:order-summary")
         else:


### PR DESCRIPTION
When you add a product with quantity of two or more, and remove this product from your cart again. When you add the product again, the old quantity is taken.