### PR TITLE
update rename.py

### DIFF
--- a/core/management/commands/rename.py
+++ b/core/management/commands/rename.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
 
         # logic for renaming the files
 
-        files_to_rename = [f'{current_project_name}/settings.py',
+        files_to_rename = [f'{current_project_name}/settings/base.py',
                            f'{current_project_name}/wsgi.py', 'manage.py']
 
         for f in files_to_rename:


### PR DESCRIPTION
`python manage.py rename old new` command throws an error because it can't find `old/settings.py`. Should be looking for `old/settings/base.py`.