### PR TITLE
Fix typo in README.md (activate instead of active) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ virtualenv env
 That will create a new folder `env` in your project directory. Next activate it with this command on mac/linux:
 
 ```
-source env/bin/active
+source env/bin/activate
 ```
 
 Then install the project dependencies with


### PR DESCRIPTION
Corrected a typo in the README.md where the command to activate the virtual environment was mistakenly written as 'source env/bin/active' instead of 'source env/bin/activate'